### PR TITLE
Fix lint error and the `rs/zerolog` chain must have call either the Msg or Msgf method

### DIFF
--- a/backend-api/main.go
+++ b/backend-api/main.go
@@ -32,16 +32,16 @@ func init() {
 
 	tomlInBytes, err := ioutil.ReadFile("config.toml")
 	if err != nil {
-		log.Fatal().AnErr("Failed reading config file", err)
+		log.Fatal().AnErr("Failed reading config file", err).Msg("")
 	}
 
 	config, err := toml.LoadBytes(tomlInBytes)
 	if err != nil {
-		log.Fatal().AnErr("Failed parsing toml file", err)
+		log.Fatal().AnErr("Failed parsing toml file", err).Msg("")
 	}
 
 	if os.Getenv("CLIENT_SECRET") == "" {
-		log.Fatal().AnErr("CLIENT_SECRET is missing", errors.New("Missing client secret"))
+		log.Fatal().AnErr("CLIENT_SECRET is missing", errors.New("Missing client secret")).Msg("")
 	}
 
 	// Maybe server config
@@ -68,7 +68,7 @@ func main() {
 
 	//server := http.Server{Addr: "localhost" + ":" + port}
 	//http.HandleFunc("/token", dumpRequest(handleTokenRequest)) //limited to Okta for now
-	log.Fatal().Err(srv.ListenAndServe())
+	log.Fatal().Err(srv.ListenAndServe()).Msg("")
 }
 
 func handleTokenRequest(w http.ResponseWriter, r *http.Request) {

--- a/backend-api/main.go
+++ b/backend-api/main.go
@@ -1,26 +1,29 @@
 package main
 
 import (
-	"errors"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"net/http"
-	"os"
-	"net/http/httputil"
-	"fmt"
-	"golang.org/x/oauth2"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"os"
 	"strconv"
 	"time"
-	"github.com/pelletier/go-toml"
-	"io/ioutil"
+
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"github.com/pelletier/go-toml"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/oauth2"
 )
 
-var oauthConfig oauth2.Config
-var port string
+var (
+	oauthConfig oauth2.Config
+	port        string
+)
 
 func init() {
 	zerolog.TimeFieldFormat = ""
@@ -45,10 +48,10 @@ func init() {
 	port = strconv.FormatInt(config.Get("env.dev.port").(int64), 10)
 
 	oauthConfig = oauth2.Config{
-		ClientID: config.Get("env.dev.as.okta.client_id").(string),
+		ClientID:     config.Get("env.dev.as.okta.client_id").(string),
 		ClientSecret: os.Getenv("CLIENT_SECRET"),
-		RedirectURL: config.Get("env.dev.as.okta.callback").(string),
-		Endpoint: oauth2.Endpoint {TokenURL: config.Get("env.dev.as.okta.token_endpoint").(string)},
+		RedirectURL:  config.Get("env.dev.as.okta.callback").(string),
+		Endpoint:     oauth2.Endpoint{TokenURL: config.Get("env.dev.as.okta.token_endpoint").(string)},
 	} //ConfigFromJSONの ConfigFromJSONが参考になる
 }
 
@@ -76,7 +79,7 @@ func handleTokenRequest(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 	var b struct {
-		AuthzCode string `json:"authz_code"`
+		AuthzCode    string `json:"authz_code"`
 		CodeVerifier string `json:"code_verifier"`
 	}
 
@@ -116,8 +119,8 @@ func handleTokenRequest(w http.ResponseWriter, r *http.Request) {
 		//Scope      string      `json:"scope"`
 	}{
 		AccessToken: token.AccessToken,
-		TokenType: token.TokenType,
-		Expiry: token.Expiry,
+		TokenType:   token.TokenType,
+		Expiry:      token.Expiry,
 	}
 
 	// They are required in https://tools.ietf.org/html/rfc6749#section-5.1
@@ -147,5 +150,5 @@ func dumpRequest(next http.HandlerFunc) http.HandlerFunc {
 type TokenResponseError struct {
 	Error            string `json:"error,omitempty"`
 	ErrorDescription string `json:"error_description,omitempty"`
-	ErrorUri         string `json:"error_uri,omitempty"`
+	ErrorURI         string `json:"error_uri,omitempty"`
 }


### PR DESCRIPTION
I read your blog and got knowledge. However, I found a strange point in the sample code. This PR fixes some questions.
I would appreciate it if you could check this PR.

#  Summary

- Apply gofmt and fix golint error.
- Fix zerolog calls.

#  Details
zerolog specification is below.
https://github.com/rs/zerolog#simple-leveled-logging-example
> It is very important to note that when using the zerolog chaining API, as shown above (log.Info().Msg("hello world"), the chain must have either the Msg or Msgf method call. If you forget to add either of these, the log will not occur and there is no compile time error to alert you of this.

The following code does not terminate and does not output any logging.

```go
log.Fatal().AnErr("CLIENT_SECRET is missing", errors.New("Missing client secret"))
```

Because, each logging codes never call `Msg`, so I add `Msg` call to each logging line.

# Test
I execute codes without `CLIENT_SECRET`, execution results are below:

## before code
```bash
$ go run backend-api/main.go
# Nothing happens...
```

## after code
```bash
$ go run backend-api/main.go
{"level":"fatal","CLIENT_SECRET is missing":"Missing client secret","caller":"/Users/budougumi0617/go/src/github.com/ken5scal/oauth-client-back/backend-api/main.go:44"}
exit status 1
```

Seems good.